### PR TITLE
Corrected the block-explorer link

### DIFF
--- a/lesson.js
+++ b/lesson.js
@@ -184,7 +184,7 @@ async function sendCELOTx(){
     let tx = await kit.sendTransaction(CeloTx)
     let receipt = await tx.waitReceipt()
 
-    console.log(`CELO tx: https://alfajores-blockscout.celo-testnet.org/tx/${receipt.transactionHash}/token_transfers `)
+    console.log(`CELO tx: https://alfajores-blockscout.celo-testnet.org/tx/${receipt.transactionHash}/token-transfers `)
 }
 
 // sendCELOTx()


### PR DESCRIPTION
Problem:
The initial Block Explorer link redirected to "Not Found Page".

Solution:
Updated the Block Explorer link.